### PR TITLE
Dual curriculum adaptation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,14 +1,17 @@
-# run: conda env create --file environment.yml
-name: attention_tsp
+# Run: conda env create --file environment.yml
+name: dcd_tsp
 channels:
-- pytorch
+  - pytorch
+  - nvidia
+  - conda-forge
+  - defaults
 dependencies:
-- python>=3.8
-- anaconda
-- tqdm
-- pytorch
-- torchvision
-- cuda91
-- pip
-- pip:
-  - tensorboard_logger
+  - python=3.10.13
+  - anaconda
+  - tqdm
+  - pytorch=2.1.1
+  - pytorch-cuda=11.8
+  - torchvision
+  - pip
+  - pip:
+    - tensorboard_logger

--- a/options.py
+++ b/options.py
@@ -56,6 +56,9 @@ def get_options(args=None):
                              ' to save memory (default None means no shrinking)')
     parser.add_argument('--data_distribution', type=str, default=None,
                         help='Data distribution to use during training, defaults and options depend on problem.')
+    parser.add_argument('--edit_fn', type=str, default=None,
+                        help="Dual curriculum edit function to use: 'global_perturb', 'local_perturb' or 'random_edit'."
+                             'Defaults to no edit function.')
 
     # Misc
     parser.add_argument('--log_step', type=int, default=50, help='Log info every log_step steps')

--- a/options.py
+++ b/options.py
@@ -57,7 +57,7 @@ def get_options(args=None):
     parser.add_argument('--data_distribution', type=str, default=None,
                         help='Data distribution to use during training, defaults and options depend on problem.')
     parser.add_argument('--edit_fn', type=str, default=None,
-                        help="Dual curriculum edit function to use: 'global_perturb', 'local_perturb' or 'random_edit'."
+                        help="Dual curriculum edit function to use: 'global_perturb', 'local_perturb' or 'random_edit'. "
                              'Defaults to no edit function. Only available for tsp problem.')
 
     # Misc

--- a/options.py
+++ b/options.py
@@ -58,7 +58,7 @@ def get_options(args=None):
                         help='Data distribution to use during training, defaults and options depend on problem.')
     parser.add_argument('--edit_fn', type=str, default=None,
                         help="Dual curriculum edit function to use: 'global_perturb', 'local_perturb' or 'random_edit'."
-                             'Defaults to no edit function.')
+                             'Defaults to no edit function. Only available for tsp problem.')
 
     # Misc
     parser.add_argument('--log_step', type=int, default=50, help='Log info every log_step steps')

--- a/problems/tsp/problem_tsp.py
+++ b/problems/tsp/problem_tsp.py
@@ -75,3 +75,6 @@ class TSPDataset(Dataset):
 
     def __getitem__(self, idx):
         return self.data[idx]
+    
+    def __setitem__(self, idx, value):
+        self.data[idx] = value

--- a/run.py
+++ b/run.py
@@ -154,13 +154,15 @@ def run(opts):
     if opts.eval_only:
         validate(model, val_dataset, opts)
     else:
+        training_dataset = None
         for epoch in range(opts.epoch_start, opts.epoch_start + opts.n_epochs):
-            train_epoch(
+            training_dataset = train_epoch(
                 model,
                 optimizer,
                 baseline,
                 lr_scheduler,
                 epoch,
+                training_dataset,
                 val_dataset,
                 problem,
                 tb_logger,

--- a/train.py
+++ b/train.py
@@ -155,17 +155,18 @@ def train_epoch(
     num_replace = train_reward.size(0) // 2
     low_idx = sorted_idx[:num_replace]
     high_idx = sorted_idx[num_replace:num_replace*2]
-    replace_idx = torch.randint(0, training_dataset.size(0), (num_replace,))
+    replace_val = [
+        training_dataset[i] for i in torch.randint(0, training_dataset.size, (num_replace,))
+    ]
 
-    training_dataset_new = training_dataset.clone()
     for i in range(num_replace):
         # Replace low_idx entries with edited high_idx entries
-        training_dataset_new[low_idx[i]] = edit_function(training_dataset[high_idx[i]])
+        training_dataset[low_idx[i]] = edit_function(training_dataset[high_idx[i]], 10)
 
         # Replace high_idx entries with uniform sample from training_dataset
-        training_dataset_new[high_idx[i]] = training_dataset[replace_idx[i]]
+        training_dataset[high_idx[i]] = replace_val[i]
     
-    return training_dataset_new
+    return training_dataset
 
 
 def train_batch(

--- a/train.py
+++ b/train.py
@@ -8,6 +8,7 @@ from torch.utils.data import DataLoader
 from torch.nn import DataParallel
 
 from nets.attention_model import set_decode_type
+from utils.level_edit import global_perturb_tensor, local_perturb_tensor, random_edit_tensor
 from utils.log_utils import log_values
 from utils import move_to
 
@@ -64,7 +65,18 @@ def clip_grad_norms(param_groups, max_norm=math.inf):
     return grad_norms, grad_norms_clipped
 
 
-def train_epoch(model, optimizer, baseline, lr_scheduler, epoch, val_dataset, problem, tb_logger, opts):
+def train_epoch(
+        model,
+        optimizer,
+        baseline,
+        lr_scheduler,
+        epoch,
+        training_dataset,
+        val_dataset,
+        problem,
+        tb_logger,
+        opts
+):
     print("Start train epoch {}, lr={} for run {}".format(epoch, optimizer.param_groups[0]['lr'], opts.run_name))
     step = epoch * (opts.epoch_size // opts.batch_size)
     start_time = time.time()
@@ -73,9 +85,12 @@ def train_epoch(model, optimizer, baseline, lr_scheduler, epoch, val_dataset, pr
         tb_logger.log_value('learnrate_pg0', optimizer.param_groups[0]['lr'], step)
 
     # Generate new training data for each epoch
-    training_dataset = baseline.wrap_dataset(problem.make_dataset(
-        size=opts.graph_size, num_samples=opts.epoch_size, distribution=opts.data_distribution))
-    training_dataloader = DataLoader(training_dataset, batch_size=opts.batch_size, num_workers=1)
+    if training_dataset == None:
+        training_dataset = problem.make_dataset(
+            size=opts.graph_size, num_samples=opts.epoch_size, distribution=opts.data_distribution
+        )
+    training_dataset_wrapped = baseline.wrap_dataset(training_dataset)
+    training_dataloader = DataLoader(training_dataset_wrapped, batch_size=opts.batch_size, num_workers=1)
 
     # Put model in train mode!
     model.train()
@@ -113,15 +128,44 @@ def train_epoch(model, optimizer, baseline, lr_scheduler, epoch, val_dataset, pr
             os.path.join(opts.save_dir, 'epoch-{}.pt'.format(epoch))
         )
 
-    avg_reward = validate(model, val_dataset, opts)
-
     if not opts.no_tensorboard:
+        avg_reward = validate(model, val_dataset, opts)
         tb_logger.log_value('val_avg_reward', avg_reward, step)
 
     baseline.epoch_callback(model, epoch)
 
     # lr_scheduler should be called at end of epoch
     lr_scheduler.step()
+
+    # Edit and return new training data if applicable
+    # Only available for TSP problem
+    edit_function = opts.edit_fn
+    if edit_function == None or opts.problem != 'tsp':
+        return None
+    elif opts.edit_fn == 'global_perturb':
+        edit_function = global_perturb_tensor
+    elif opts.edit_fn == 'local_perturb':
+        edit_function = local_perturb_tensor
+    elif opts.edit_fn == 'random_edit':
+        edit_function = random_edit_tensor
+    
+    train_reward = rollout(model, training_dataset, opts)
+    sorted_idx = torch.argsort(train_reward)
+
+    num_replace = train_reward.size(0) // 2
+    low_idx = sorted_idx[:num_replace]
+    high_idx = sorted_idx[num_replace:num_replace*2]
+    replace_idx = torch.randint(0, training_dataset.size(0), (num_replace,))
+
+    training_dataset_new = training_dataset.clone()
+    for i in range(num_replace):
+        # Replace low_idx entries with edited high_idx entries
+        training_dataset_new[low_idx[i]] = edit_function(training_dataset[high_idx[i]])
+
+        # Replace high_idx entries with uniform sample from training_dataset
+        training_dataset_new[high_idx[i]] = training_dataset[replace_idx[i]]
+    
+    return training_dataset_new
 
 
 def train_batch(

--- a/utils/level_edit.py
+++ b/utils/level_edit.py
@@ -58,6 +58,7 @@ def random_edit_tensor(tensor, percentage):
     Randomly edits a percentage of rows in a given tensor.
     """
     # Calculate the number of rows to edit
+    assert 0 <= percentage <= 100, "Percentage must be between 0 and 100"
     num_rows = int(tensor.size(0) * (percentage / 100))
 
     # Select random indices to edit

--- a/utils/level_edit.py
+++ b/utils/level_edit.py
@@ -1,0 +1,70 @@
+import torch
+import numpy as np
+
+
+def global_perturb_tensor(tensor, percentage, max_perturb_degree=0.1):
+    """
+    Randomly perturbs a percentage of rows in a given tensor to varying degrees.
+    """
+    # Calculate the number of rows to perturb
+    assert 0 <= percentage <= 100, "Percentage must be between 0 and 100"
+    num_rows = int(tensor.size(0) * (percentage / 100))
+
+    # Select random indices to perturb
+    idx_perturb = np.random.choice(tensor.size(0), num_rows, replace=False)
+
+    for idx in idx_perturb:
+        # Generate a random perturbation magnitude between 0 and max_perturb_degree
+        perturb_mag = torch.rand(1).item() * max_perturb_degree
+
+        # Apply the perturbation with the generated magnitude
+        perturbation = (torch.rand(tensor[idx].shape) - 0.5) * 2 * perturb_mag
+        tensor[idx] = torch.clamp(tensor[idx] + perturbation, 0.0, 1.0)
+
+    return tensor
+
+
+def local_perturb_tensor(tensor, percentage, max_perturb_degree=0.1):
+    """
+    Randomly perturbs a sector of spatially close rows in a given tensor to varying degrees.
+    """
+    # Calculate the number of rows to perturb
+    assert 0 <= percentage <= 100, "Percentage must be between 0 and 100"
+    num_rows = int(tensor.size(0) * (percentage / 100))
+
+    # Choose a random center point
+    center_idx = np.random.choice(tensor.size(0), 1)[0]
+    center_point = tensor[center_idx]
+
+    # Calculate distances from the center point to all other points
+    distances = torch.norm(tensor - center_point, dim=1)
+
+    # Select the indices of the closest `num_rows` points
+    idx_perturb = torch.argsort(distances)[:num_rows].tolist()
+
+    for idx in idx_perturb:
+        # Generate a random perturbation magnitude between 0 and max_perturb_degree
+        perturb_mag = torch.rand(1).item() * max_perturb_degree
+
+        # Apply the perturbation with the generated magnitude
+        perturbation = (torch.rand(tensor[idx].shape) - 0.5) * 2 * perturb_mag
+        tensor[idx] = torch.clamp(tensor[idx] + perturbation, 0.0, 1.0)
+
+    return tensor
+
+
+def random_edit_tensor(tensor, percentage):
+    """
+    Randomly edits a percentage of rows in a given tensor.
+    """
+    # Calculate the number of rows to edit
+    num_rows = int(tensor.size(0) * (percentage / 100))
+
+    # Select random indices to edit
+    idx_edit = np.random.choice(tensor.size(0), num_rows, replace=False)
+
+    for idx in idx_edit:
+        # Edit the specified rows by replacing with random values
+        tensor[idx] = torch.rand(tensor[idx].shape)
+
+    return tensor


### PR DESCRIPTION
Specify the edit function via the `edit_fn` param, which can be "global_perturb", "local_perturb", or "random_edit"

Sample command:
```
python run.py --problem tsp --graph_size 20 --baseline rollout --edit_fn global_perturb --epoch_size 4096 --batch_size 128 --n_epochs 100 --checkpoint_epochs 10 --run_name tsp20_dcd
```